### PR TITLE
Implement article write methods and fix mapper

### DIFF
--- a/src/main/java/com/example/demo/repository/ArticleRepository.java
+++ b/src/main/java/com/example/demo/repository/ArticleRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.example.demo.vo.Article;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ArticleRepository {
@@ -21,7 +22,7 @@ public interface ArticleRepository {
 
 	public List<Article> getArticles();
 
-	public Article getForPrintArticle(int loginedMemberId);
+       public Article getForPrintArticle(@Param("id") int id);
 
 	public List<Article> getForPrintArticles(int boardId, int limitFrom, int limitTake, String searchKeywordTypeCode,
 			String searchKeyword);

--- a/src/main/java/com/example/demo/service/ArticleService.java
+++ b/src/main/java/com/example/demo/service/ArticleService.java
@@ -158,12 +158,12 @@ public class ArticleService {
 		return articleRepository.getGoodRP(relId);
 	}
 
-	public int getBadRP(int relId) {
-		return articleRepository.getBadRP(relId);
-	}
+       public int getBadRP(int relId) {
+               return articleRepository.getBadRP(relId);
+       }
 
-	public void writeArticle(int loginedMemberId, String title, String body, int farmBoardId) {
-		// TODO Auto-generated method stub
+       public void writeArticle(int loginedMemberId, String title, String body, int farmBoardId) {
+               articleRepository.writeArticle(loginedMemberId, title, body, String.valueOf(farmBoardId));
 
 	}
 

--- a/src/main/java/com/example/demo/service/FarmlogService.java
+++ b/src/main/java/com/example/demo/service/FarmlogService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.demo.repository.FarmlogRepository;
+import com.example.demo.service.ArticleService;
 
 import com.example.demo.vo.Farmlog;
 import com.example.demo.vo.ResultData;
@@ -14,8 +15,11 @@ import com.example.demo.vo.ResultData;
 @Service
 public class FarmlogService {
 
-	@Autowired
-	private FarmlogRepository farmlogRepository;
+        @Autowired
+        private FarmlogRepository farmlogRepository;
+
+       @Autowired
+       private ArticleService articleService;
 
 	// 영농일지 등록
 	public ResultData writeFarmlog(int loginedMemberId, Integer crop_variety_id, String work_type, String activity_type,
@@ -52,10 +56,10 @@ public class FarmlogService {
 		return null;
 	}
 
-	public void writeArticle(int loginedMemberId, String string, String work_memo, int i) {
-		// TODO Auto-generated method stub
+       public void writeArticle(int loginedMemberId, String title, String work_memo, int boardId) {
+               articleService.writeArticle(loginedMemberId, title, work_memo, boardId);
 
-	}
+       }
 
 	public List<Farmlog> getForPrintFarmlogs(int id, int member_id, int crop_variety_id, int work_type_id,
 			int agrochemical_id, String work_date, String work_memo) {

--- a/src/main/resources/mappers/CropRepository.xml
+++ b/src/main/resources/mappers/CropRepository.xml
@@ -5,11 +5,18 @@
 
 <mapper namespace="com.example.demo.repository.CropRepository">
 
-	<insert id="insertIgnoreDuplicate">
-		INSERT IGNORE INTO crop
-		SET category_code = #{categoryCode},
-		category_name = #{categoryName},
-		crop_code = #{cropCode},
-		crop_name = #{cropName}
-	</insert>
+        <insert id="insertIgnoreDuplicate">
+                INSERT IGNORE INTO crop
+                SET category_code = #{categoryCode},
+                category_name = #{categoryName},
+                crop_code = #{cropCode},
+                crop_name = #{cropName}
+        </insert>
+
+        <select id="getAllCropVarietiesWithCategoryAndName" resultType="map">
+                SELECT c.category, c.crop_name, v.variety_name
+                FROM crop_variety v
+                JOIN crop c ON v.crop_code = c.crop_code
+                ORDER BY c.category, c.crop_name
+        </select>
 </mapper>


### PR DESCRIPTION
## Summary
- implement missing writeArticle in `ArticleService`
- let `FarmlogService` use `ArticleService` when creating farm logs
- fix parameter binding for `getForPrintArticle` mapper

## Testing
- `./mvnw -q -DskipTests compile` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684143d7382083269ed5e885f5f72ecf